### PR TITLE
GitHub Actions workflow to build TeamSpeak Plugin

### DIFF
--- a/.github/workflows/teamspeak-plugin.yml
+++ b/.github/workflows/teamspeak-plugin.yml
@@ -1,0 +1,27 @@
+name: TeamSpeak Plugin
+
+on:
+  push:
+    branches:
+      - main
+  pull_request:
+    branches:
+      - main
+
+permissions:
+  contents: read
+
+jobs:
+  build:
+    name: Build
+    runs-on: windows-latest
+    steps:
+    - name: Checkout
+      uses: actions/checkout@v4
+
+    - name: Add MSBuild to PATH
+      uses: microsoft/setup-msbuild@v2
+
+    - name: Build
+      working-directory: CoalitionTeamspeakPlugin/src
+      run: msbuild /m /p:Configuration=Release /p:Platform=x64 Coalition_Teamspeak_Plugin.sln


### PR DESCRIPTION
Ensures TeamSpeak Plugin can be built for pushes and pull requests to `main`.

Example build in fork: https://github.com/Dahlgren/Coalition-VON/actions/runs/17711959970/job/50331788218

This could be extended later on to auto publish a release on GitHub with the latest TeamSpeak Plugin binary.