### PR TITLE
OnDelete and Race Condition

### DIFF
--- a/CoalitionVON/scripts/Game/Vanilla Overrides/CVON_SCR_CharacterInventoryStorageComponent.c
+++ b/CoalitionVON/scripts/Game/Vanilla Overrides/CVON_SCR_CharacterInventoryStorageComponent.c
@@ -30,7 +30,27 @@ modded class SCR_CharacterInventoryStorageComponent
 		SCR_PlayerController pc = SCR_PlayerController.Cast(GetGame().GetPlayerManager().GetPlayerController(playerId));
 		if (!pc)
 			return;
-		pc.m_aRadios.Insert(item);
+		
+		// Insert maintaining [SR..., LR...] order so m_aRadios[0] is always the SR radio,
+		// matching the sort done in InitializeRadios. Without this, if the LR radio's
+		// inventory event arrives before the SR radio's (common due to replication timing),
+		// the array ends up [LR, SR] and Caps Lock transmits on the wrong radio until the
+		// player rotates with VONRotateActive.
+		CVON_RadioComponent newRadioComp = CVON_RadioComponent.Cast(item.FindComponent(CVON_RadioComponent));
+		if (newRadioComp && newRadioComp.m_eRadioType == CVON_ERadioType.SHORT)
+		{
+			int insertIdx = 0;
+			for (int i = 0; i < pc.m_aRadios.Count(); i++)
+			{
+				CVON_RadioComponent rc = CVON_RadioComponent.Cast(pc.m_aRadios[i].FindComponent(CVON_RadioComponent));
+				if (rc && rc.m_eRadioType == CVON_ERadioType.LONG)
+					break;
+				insertIdx++;
+			}
+			pc.m_aRadios.InsertAt(item, insertIdx);
+		}
+		else
+			pc.m_aRadios.Insert(item);
 	}
 	
 	override void HandleOnItemRemovedFromInventory( IEntity item, BaseInventoryStorageComponent storageOwner )

--- a/CoalitionVON/scripts/Game/Vanilla Overrides/CVON_SCR_VONController.c
+++ b/CoalitionVON/scripts/Game/Vanilla Overrides/CVON_SCR_VONController.c
@@ -521,6 +521,44 @@ modded class SCR_VONController
 		if (!m_MenuManager)
 			m_MenuManager = GetGame().GetMenuManager();
 	}
+	
+	//==========================================================================================================================================================================
+	// OnDelete: called by the engine when the PlayerController entity is explicitly removed
+	// (normal disconnect, server kick, mission end). More reliable than the destructor
+	// for normal disconnects; crashes cannot be caught by either.
+	//==========================================================================================================================================================================
+	override void OnDelete(IEntity owner)
+	{
+		// Remove any active broadcasts before cleanup
+		if (m_PlayerController && m_aPlayerIdsBroadcastedTo.Count() > 0)
+		{
+			foreach (int playerId: m_aPlayerIdsBroadcastedTo)
+				m_PlayerController.BroadcastRemoveLocalVONToServer(m_PlayerController.GetPlayerId());
+			m_aPlayerIdsBroadcastedTo.Clear();
+		}
+		
+		// Signal TeamSpeak to return user to their previous channel
+		SCR_JsonSaveContext VONServerData = new SCR_JsonSaveContext();
+		VONServerData.StartObject("ServerData");
+		VONServerData.WriteValue("InGame", false);
+		VONServerData.WriteValue("InGameName", "");
+		VONServerData.WriteValue("TSClientID", 0);
+		VONServerData.WriteValue("TSPluginVersion", "");
+		VONServerData.WriteValue("VONChannelName", "");
+		VONServerData.WriteValue("VONChannelPassword", "");
+		VONServerData.WriteValue("TSServerIp", "");
+		VONServerData.WriteValue("TSServerPassword", "");
+		VONServerData.EndObject();
+		VONServerData.SaveToFile("$profile:/VONServerData.json");
+		
+		// Clear VONData.json so TeamSpeak unmutes all clients
+		SCR_JsonSaveContext VONDataClear = new SCR_JsonSaveContext();
+		VONDataClear.WriteValue("IsTransmitting", false);
+		VONDataClear.SaveToFile("$profile:/VONData.json");
+		
+		super.OnDelete(owner);
+	}
+	
 	//The meat, this is where we determine who we send a VONEntry too and if we've already sent one.
 	//Differentiates behavior for Direct and Radio in here as well. If a player is more than 200m away and you try to use direct he will not receive that direct VONEntry.
 	//==========================================================================================================================================================================
@@ -1309,31 +1347,4 @@ modded class SCR_VONController
 	}
 	
 	
-	//Resets these values so we can leave the channel on teamspeak
-	//It checks if the bool InGame is true, and if so moves you to the voip channel
-	//==========================================================================================================================================================================
-	void ~SCR_VONController()
-	{
-		if (m_aPlayerIdsBroadcastedTo.Count() > 0)
-		{
-			foreach (int playerId: m_aPlayerIdsBroadcastedTo)
-			{
-				m_PlayerController.BroadcastRemoveLocalVONToServer(m_PlayerController.GetPlayerId());
-			}
-			m_aPlayerIdsBroadcastedTo.Clear();
-		}
-		
-		SCR_JsonSaveContext VONServerData = new SCR_JsonSaveContext();
-		VONServerData.StartObject("ServerData");
-		VONServerData.WriteValue("InGame", false);
-		VONServerData.WriteValue("InGameName", "");
-		VONServerData.WriteValue("TSClientID", 0);
-		VONServerData.WriteValue("TSPluginVersion", 0);
-		VONServerData.WriteValue("VONChannelName", "");
-		VONServerData.WriteValue("VONChannelPassword", "");
-		VONServerData.WriteValue("TSServerIp", "");
-		VONServerData.WriteValue("TSServerPassword", "");
-		VONServerData.EndObject();
-		VONServerData.SaveToFile("$profile:/VONServerData.json");
-	}
 }


### PR DESCRIPTION
Fixes the race condition where the 500ms `InitializeRadios()` delay causes the radio array to clear after its already been defined.